### PR TITLE
[CRITICAL] Social Links XSS Injection Vulnerability

### DIFF
--- a/views/pages/profile/profile.ejs
+++ b/views/pages/profile/profile.ejs
@@ -86,15 +86,59 @@
 					</div>
 				</div>
 				<div id="medias">
-					<% if(profileInfo.medias.youtube){ %> <a href="<%- profileInfo.medias.youtube %>" title="YouTube channel" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(/images/icons/youtube.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.github){ %> <a href="https://github.com/<%- profileInfo.medias.github %>" title="GitHub profile" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(https://github.com/favicon.ico)"></span></a> <% } %>
-					<% if(profileInfo.medias.website){ %> <a href="<%- profileInfo.medias.website %>" title="Personal website" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(/images/icons/domain.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.discordtag){ %> <a onClick="prompt('Discord Contact:', '<%- profileInfo.medias.discordtag %>')" title="Discord Contact" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(/images/icons/discord.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.discord){ %> <a href="<%- profileInfo.medias.discord %>" title="Discord Server" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(/images/icons/discord.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.v3rmillion){ %> <a href="<%- profileInfo.medias.v3rmillion %>" title="V3rmillion Profile" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(/images/icons/v3rm.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.snapchat){ %> <a onClick="prompt('Snapchat username:', '<%- profileInfo.medias.snapchat %>')" title="Snapchat Username"><span class="profile_mediaicon" style="background-image: url(/images/icons/snapchat.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.twitter){ %> <a href="https://twitter.com/<%- profileInfo.medias.twitter %>" title="Twitter profile" target="_blank" rel="noopener noreferrer"><span class="profile_mediaicon" style="background-image: url(/images/icons/twitter.png)"></span></a> <% } %>
-					<% if(profileInfo.medias.facebook){ %> <a href="<%- profileInfo.medias.facebook %>" target="_blank" rel="noopener noreferrer" title="Facebook Page"><span class="profile_mediaicon" style="background-image: url(/images/icons/facebook.png)"></span></a> <% } %>
+					<% if (profileInfo.medias.youtube) { %>
+						<a href="<%- profileInfo.medias.youtube %>" title="YouTube channel" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/youtube.png)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.github) { %>
+						<a href="https://github.com/<%- profileInfo.medias.github %>" title="GitHub profile" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(https://github.com/favicon.ico)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.website) { %>
+						<a href="<%- profileInfo.medias.website %>" title="Personal website" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/domain.png)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.discordtag) { %>
+						<a onClick="prompt('Discord Contact:', '<%= profileInfo.medias.discordtag.replace(/'/g, "\\'") %>')" title="Discord Contact" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/discord.png)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.discord) { %>
+						<a href="<%- profileInfo.medias.discord %>" title="Discord Server" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/discord.png)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.v3rmillion) { %>
+						<a href="<%- profileInfo.medias.v3rmillion %>" title="V3rmillion Profile" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/v3rm.png)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.snapchat) { %>
+						<a onClick="prompt('Snapchat username:', '<%- profileInfo.medias.snapchat.replace(/'/g, "\\'") %>')" title="Snapchat Username">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/snapchat.png)"></span>
+						</a>
+					  <% } %>
+					
+					  <% if (profileInfo.medias.twitter) { %>
+						<a href="https://twitter.com/<%- profileInfo.medias.twitter %>" title="Twitter profile" target="_blank" rel="noopener noreferrer">
+						  <span class="profile_mediaicon" style="background-image: url(/images/icons/twitter.png)"></span>
+						</a>
+					  <% } %>
+
+					<% if(profileInfo.medias.facebook) { %> 
+						<a href="<%- profileInfo.medias.facebook %>" target="_blank" rel="noopener noreferrer" title="Facebook Page">
+							<span class="profile_mediaicon" style="background-image: url(/images/icons/facebook.png)"></span>
+						</a>
+					  <% } %>
 				</div>
 				<img id="profile_mainprofilepicture" class="border1" src="<%= profileInfo.profilepicture %>" alt="Profile Picture"/>
 			</div>


### PR DESCRIPTION
While testing some stuff with social links and prompts, I found an XSS vulnerability that trolls could exploit to wreak havoc. As you know, we need to keep the trolls out and ensure the community stays safe, The old code was spaghetti (no offense) and could have led to a security breach including IP logging, Cookie logging, etc.

I've updated the code to prevent XSS attacks by properly escaping user input, I ran some tests and everything seems to be working perfectly.

## How to reproduce?
Basically, change the Discord/Snapchat value to start with `');`, that would break outside the prompt function, now you can inject anything after that, as long it won't trigger the content length limit, for example: `');alert(document.cookie)//#1234`.

```js
fetch("https://forum.wearedevs.net/api/account/manager/info", {
    "headers": {
        "accept": "*/*",
        "accept-language": "en-US,en;q=0.9",
        "content-type": "application/json",
        "sec-ch-ua": "\"Google Chrome\";v=\"113\", \"Chromium\";v=\"113\", \"Not-A.Brand\";v=\"24\"",
        "sec-ch-ua-mobile": "?0",
        "sec-ch-ua-platform": "\"Windows\"",
        "sec-fetch-dest": "empty",
        "sec-fetch-mode": "cors",
        "sec-fetch-site": "same-origin",
        "cookie": "go away",
        "Referer": "https://forum.wearedevs.net/manager/info",
        "Referrer-Policy": "strict-origin-when-cross-origin"
    },
    "body": "{\"discordtag\":\"');alert(1)//#1234\"}",
    "method": "POST"
}).then(res => res.json())
    .then(data => {
        console.log(data)
    }).catch(err => {
        console.log(err)
    });
```

Could been worse if someone found a method to bypass content length, and I would suggest not to use `prompt()`
